### PR TITLE
Bump Terraform to 1.3.0. Bump AWS provder to 4.35.0

### DIFF
--- a/certificates.tf
+++ b/certificates.tf
@@ -8,13 +8,6 @@ resource "aws_acm_certificate" "certificates" {
   }
   lifecycle {
     create_before_destroy = true
-    ignore_changes = [
-      # We ignore changes in the status field.
-      # Otherwise, the certificate's status field changing from
-      # "PENDING_VALIDATION" to "ISSUED" would be considered
-      # as "drift" by Terraform.
-      status,
-    ]
   }
 }
 

--- a/lustre_file_systems.tf
+++ b/lustre_file_systems.tf
@@ -44,15 +44,6 @@ resource "aws_fsx_lustre_file_system" "lustre_file_systems" {
   export_path                 = try(each.value.s3_export_path, null)
   imported_file_chunk_size    = try(each.value.imported_file_chunk_size_mb, null)
   auto_import_policy          = try(each.value.auto_import_policy, "NONE")
-  lifecycle {
-    # Not sure if this fixes anything, but we put this here because
-    # there seem to be some weirdness with Terraform tainting this
-    # resource.
-    # TOOD: Investigate why `aws_fsx_lustre_file_system` resources get automatically tainted.
-    ignore_changes = [
-      network_interface_ids
-    ]
-  }
   tags = {
     Name    = each.key
     Provose = var.provose_config.name

--- a/modules/load_balancer_s3_log_buckets/providers.tf
+++ b/modules/load_balancer_s3_log_buckets/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.14.0"
+      version = "4.35.0"
     }
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "4.14.0"
+      version = "4.35.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,5 @@
 terraform {
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
+  required_version = ">= 1.3.0"
 }
 
 variable "batch" {


### PR DESCRIPTION
This takes care of some validation/incompatibility issues with how newer versions of Terraform handle variables.