### PR TITLE
Fix container docs to show required AMI

### DIFF
--- a/docs/reference/containers.md
+++ b/docs/reference/containers.md
@@ -48,9 +48,9 @@ This example shows ten nginx "Hello World" containers running on AWS Fargate.
 
 - `instances` -- **Required.** This is an object that defines how this container is run.
 
-  - `ami_id` -- **Required.** The ID of the Amazon Machine Image (AMI) to deploy for this instance.
-
   - `instance_type` -- **Required.** Set this to `"FARGATE"` to deploy the containers on AWS Fargate. Set this to `"FARGATE_SPOT"` to use Fargate with Spot instances--which can [give cost savings of up to 70%](https://aws.amazon.com/blogs/compute/deep-dive-into-fargate-spot-to-run-your-ecs-tasks-for-up-to-70-less/). Note that with Fargate, it will not be possible to use `bind_mounts` to mount to the host. However, if you want to deploy these containers on AWS EC2 instances, set this to the instance type of your choice, like `"t3.small"`. Keep in mind that AWS does not make all instance types available in all Availability Zones.
+
+  - `ami_id` -- **Required.** The ID of the Amazon Machine Image (AMI) to deploy for this instance. This is required when the instance type is *not* `"FARGATE"` or `'FARGATE_SPOT"`.
 
   - `container_count` -- **Required.** This is the number of containers to deploy.
 

--- a/docs/reference/examples/containers/hello_ec2.tf
+++ b/docs/reference/examples/containers/hello_ec2.tf
@@ -27,6 +27,11 @@ module "myproject-ec2" {
       }
       instances = {
         instance_type   = "t2.small"
+        /* Make sure to use an AWS AMI that is ECS-optimized.
+         * You can search for ECS-optimized AMIs in the
+         * AWS AMI catalog:
+         * https://us-west-1.console.aws.amazon.com/ec2/v2/ */
+        ami_id          = "ami-0f71b77f57e47333c"
         container_count = 4
         instance_count  = 2
         cpu             = 256

--- a/docs/reference/examples/containers/hello_ec2.tf
+++ b/docs/reference/examples/containers/hello_ec2.tf
@@ -26,7 +26,7 @@ module "myproject-ec2" {
         }
       }
       instances = {
-        instance_type   = "t2.small"
+        instance_type = "t2.small"
         /* Make sure to use an AWS AMI that is ECS-optimized.
          * You can search for ECS-optimized AMIs in the
          * AWS AMI catalog:


### PR DESCRIPTION
Provose no longer uses a default AWS AMI when deploying EC2 instances. This change updates the Provose documentation and example to show that an AMI ID is required.